### PR TITLE
Bug 1690681: Generate absolute URLs in emails

### DIFF
--- a/moz-extensions/src/email/resolve/ResolveComments.php
+++ b/moz-extensions/src/email/resolve/ResolveComments.php
@@ -182,6 +182,7 @@ class ResolveComments {
     return PhabricatorMarkupEngine::newMarkupEngine(array())
       ->setConfig('viewer', PhabricatorUser::getOmnipotentUser())
       ->setConfig('uri.base', PhabricatorEnv::getProductionURI('/'))
+      ->setConfig('uri.full', true)
       ->setMode($mode);
   }
 }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1690681#c2

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1690681

Supersedes https://github.com/mozilla-services/phabricator-extensions/pull/70
Verified by @mitchhentges at https://github.com/mozilla-services/phabricator-extensions/pull/70#issuecomment-880066377