### PR TITLE
Bug 1735635: Use Python 3.7 to ensure wheel usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,23 +12,24 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:19.03.13-git
+      - image: debian:10-slim
     steps:
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.7
+      - run:
+          name: Install system packages
+          command: |
+            cd $HOME
+            apt-get update && apt-get install -y git curl python3 python3-pip && \
+            curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.7.tgz -O && \
+            tar xvf docker-20.10.7.tgz && \
+            cp docker/* /usr/bin/
       - checkout
       - run:
           name: Install pip
           command: |
-            apk add --no-cache bash gcc libffi-dev make musl-dev openssl-dev python3 python3-dev && \
-            python3 -m ensurepip && \
-            rm -r /usr/lib/python*/ensurepip && \
-            pip3 install --upgrade docker-compose invoke pip && \
-            if [[ ! -e /usr/bin/pip  ]]; then ln -s pip3 /usr/bin/pip; fi && \
-            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-            rm -r /root/.cache
-          environment:
-            CRYPTOGRAPHY_DONT_BUILD_RUST: 1
+            python3 -m pip install --upgrade pip && \
+            python3 -m pip install docker-compose invoke
       - run:
           name: Create version.json
           command: |


### PR DESCRIPTION
Currently, CI is trying to build the `cryptography` package
(needed by `docker-compose`) from scratch. It's failing due to
the Rust compiler being missing.

However, we don't need to compile `cryptography` if we use the
prebuilt "wheel", which was being ignored because the `wheel`
package wasn't installed.