### PR TITLE
Bug 1734925: Send emails to reviewer group "watchers"

### DIFF
--- a/moz-extensions/src/email/adapter/GroupPhabricatorReviewer.php
+++ b/moz-extensions/src/email/adapter/GroupPhabricatorReviewer.php
@@ -5,14 +5,17 @@ class GroupPhabricatorReviewer implements PhabricatorReviewer {
   private string $name;
   /** @var PhabricatorUser[] */
   private array $rawUsers;
+  private array $rawWatcherUsers;
 
   /**
    * @param string $name
    * @param PhabricatorUser[] $rawUsers
+   * @param PhabricatorUser[] $rawWatcherUsers
    */
-  public function __construct(string $name, array $rawUsers) {
+  public function __construct(string $name, array $rawUsers, array $rawWatcherUsers) {
     $this->name = $name;
     $this->rawUsers = $rawUsers;
+    $this->rawWatcherUsers = $rawWatcherUsers;
   }
 
   public function name(): string {
@@ -23,5 +26,12 @@ class GroupPhabricatorReviewer implements PhabricatorReviewer {
     return array_values(array_filter(array_map(function($user) use ($actorEmail) {
       return EmailRecipient::from($user, $actorEmail);
     }, $this->rawUsers)));
+  }
+
+  public function getWatchersAsRecipients(string $actorEmail): array
+  {
+    return array_values(array_filter(array_map(function($user) use ($actorEmail) {
+      return EmailRecipient::from($user, $actorEmail);
+    }, $this->rawWatcherUsers)));
   }
 }

--- a/moz-extensions/src/email/adapter/PhabricatorReviewer.php
+++ b/moz-extensions/src/email/adapter/PhabricatorReviewer.php
@@ -8,4 +8,9 @@ interface PhabricatorReviewer {
    * @return EmailRecipient[]
    */
   public function toRecipients(string $actorEmail): array;
+
+  /**
+   * @return EmailRecipient[]
+   */
+  public function getWatchersAsRecipients(string $actorEmail): array;
 }

--- a/moz-extensions/src/email/adapter/PhabricatorUserStore.php
+++ b/moz-extensions/src/email/adapter/PhabricatorUserStore.php
@@ -62,12 +62,13 @@ class PhabricatorUserStore {
       // This is a group reviewer
       $project = self::fetchProject($PHID);
       $users = array_values($this->queryAll($project->getMemberPHIDs()));
-      return new GroupPhabricatorReviewer($project->getDisplayName(), $users);
+      $watchers = array_values($this->queryAll($project->getWatcherPHIDs()));
+      return new GroupPhabricatorReviewer($project->getDisplayName(), $users, $watchers);
     } else if (substr($PHID, 0, strlen('PHID-OPKG')) == 'PHID-OPKG') {
       // This is a "code owner" reviewer
       $package = self::fetchPackage($PHID);
       $users = array_values($this->queryAll($package->getOwnerPHIDs()));
-      return new GroupPhabricatorReviewer($package->getName(), $users);
+      return new GroupPhabricatorReviewer($package->getName(), $users, []);
     } else {
       // PHID type must be "PHID-USER".
       // So, this is a single user reviewer.
@@ -95,6 +96,7 @@ class PhabricatorUserStore {
     return (new PhabricatorProjectQuery())
       ->setViewer(PhabricatorUser::getOmnipotentUser())
       ->needMembers(true)
+      ->needWatchers(true)
       ->withPHIDs([$PHID])
       ->executeOne();
   }

--- a/moz-extensions/src/email/adapter/UserPhabricatorReviewer.php
+++ b/moz-extensions/src/email/adapter/UserPhabricatorReviewer.php
@@ -15,4 +15,9 @@ class UserPhabricatorReviewer implements PhabricatorReviewer {
   public function toRecipients(string $actorEmail): array {
     return array_filter([EmailRecipient::from($this->rawUser, $actorEmail)]);
   }
+
+  public function getWatchersAsRecipients(string $actorEmail): array
+  {
+    return [];
+  }
 }


### PR DESCRIPTION
There's three kinds of reviewers:
* User reviewers
* Code owner reviewers
* Group (project) reviewers

"Projects" can be watched by other users, and it's useful for
onboarding (such as if new build engineers watch #build).

So, we need to parse the list of reviewers and see if any
of them have subscribers/watchers attached, and pass that
through to the "subscribers"/"recipients" output fields.