### PR TITLE
Bug 1738698: update admin panel login url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ preconfigured Firefox.
 ## Preconfigured users:
 
 For performing administration tasks in Phabricator, first log out of
-Phabricator and then go to http://phabricator.test/?admin=1
+Phabricator and then go to the login page with the `Login using BMO` button
+and add `?admin=1` to the URL. You can also navigate directly to
+http://phabricator.test/auth/login/password:self/
 
 `user:admin`, `password:password123456789!`
 


### PR DESCRIPTION
Passing `?admin` as a query string parameter only works from the
`Login with BMO` page, so clarify the readme to include this
information. Looking at `webroot/rsrc/js/PhabricatorBMOAuth.js`
the query string just re-reoutes to `/auth/login/password:self`, so
also recommend connecting there directly.
