### PR TITLE
Bug 1738776: put moz-extensions directory into a volume and mount into the test environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,10 @@ services:
     entrypoint: /app/entrypoint.sh
     command: test_phab
     environment: *phab_env
-    restart: on-failure
     depends_on:
       - phabdb
+    volumes:
+      - phabricator-moz-extensions-local:/app/moz-extensions
 
   phabdb:
     image: mysql:5.7
@@ -70,3 +71,9 @@ services:
 volumes:
   phabricator-mysql-db:
   phabricator-app:
+  phabricator-moz-extensions-local:
+    driver: local
+    driver_opts:
+      type: none
+      device: '$PWD/moz-extensions'
+      o: bind


### PR DESCRIPTION
Add the `moz-extensions/` directory as a Docker
volume and mount that volume into the test container.
This makes `docker-compose run test_phab` use the
code local to the working directory allowing for
faster iteration when testing.

We also unset `restart-failure` in the test environment
as this causes the container to restart when any test
fails, however the container can't restart and hangs
around.
