### PR TITLE
Bug 1739625: Skip Phab API when filtering by an empty list of PHIDs

### DIFF
--- a/moz-extensions/src/email/adapter/PhabricatorUserStore.php
+++ b/moz-extensions/src/email/adapter/PhabricatorUserStore.php
@@ -81,6 +81,10 @@ class PhabricatorUserStore {
    * @return PhabricatorUser[]
    */
   public function queryAll(array $PHIDs): array {
+    if (empty($PHIDs)) {
+      return [];
+    }
+
     $users = (new PhabricatorPeopleQuery())
       ->setViewer(PhabricatorUser::getOmnipotentUser())
       ->withPHIDs($PHIDs)


### PR DESCRIPTION
`PhabricatorPeopleQuery()` fails when `withPHIDs([])` is called with
an empty list.
We can avoid this failure by immediately returnin `[]` if the `$PHIDs`
list is empty.