### PR TITLE
Bug 1738776: put moz-extensions directory into a volume and mount into the test environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,19 @@ services:
     depends_on:
       - phabdb
 
+  test_phab_local:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: test
+    entrypoint: /app/entrypoint.sh
+    command: test_phab
+    environment: *phab_env
+    depends_on:
+      - phabdb
+    volumes:
+      - phabricator-moz-extensions-local:/app/moz-extensions
+
   phabdb:
     image: mysql:5.7
     volumes:
@@ -70,3 +83,9 @@ services:
 volumes:
   phabricator-mysql-db:
   phabricator-app:
+  phabricator-moz-extensions-local:
+    driver: local
+    driver_opts:
+      type: none
+      device: '$PWD/moz-extensions'
+      o: bind

--- a/tasks.py
+++ b/tasks.py
@@ -51,6 +51,12 @@ def buildtest(ctx):
 
 
 @task
+def buildtestlocal(ctx):
+    """Test phabricator extensions."""
+    ctx.run("docker-compose build test_phab_local")
+
+
+@task
 def test(ctx):
     """Test phabricator extensions."""
     ctx.run("docker-compose run test_phab")


### PR DESCRIPTION
This commit is the same content as #8, but the content is pasted
into a new docker-compose service instead of overwriting `test_phab`
which is used in CI.
