### PR TITLE
Bug 1751482: Don't send "revision-updated" event if no local changes

### DIFF
--- a/moz-extensions/src/email/FeedForEmailQueryAPIMethod.php
+++ b/moz-extensions/src/email/FeedForEmailQueryAPIMethod.php
@@ -264,6 +264,11 @@ final class FeedForEmailQueryAPIMethod extends ConduitAPIMethod {
           }
         } else if ($eventKind->publicKind == EventKind::$UPDATE) {
           $reviewers = $resolveUsers->resolveReviewers($resolveRevisionStatus->resolveIsNeedingReview());
+          if (!$resolveCodeChange->resolveAnyDiffChanges()) {
+            // There were no changes as part of this update, so don't
+            // send an email for it.
+            continue;
+          }
           if ($isSecure) {
             $body = new SecureEmailRevisionUpdated(
               $resolveRevisionStatus->resolveLandoLink(),

--- a/moz-extensions/src/email/resolve/ResolveCodeChange.php
+++ b/moz-extensions/src/email/resolve/ResolveCodeChange.php
@@ -12,6 +12,74 @@ class ResolveCodeChange {
     $this->diffStore = $diffStore;
   }
 
+  public function resolveAnyDiffChanges(): bool {
+    if ($this->transactions->attemptGetTransactionWithType('differential.revision.summary')) {
+      // The commit message/summary/bug/etc change
+      return true;
+    }
+
+    $updateTx = $this->transactions->getTransactionWithType('differential:update');
+    $oldDiff = $this->diffStore->find($updateTx->getOldValue());
+    $newDiff = $this->diffStore->find($updateTx->getNewValue());
+    $oldChangesets = $oldDiff->getChangesets();
+    $newChangesets = $newDiff->getChangesets();
+
+    if (count($oldChangesets) != count($newChangesets)) {
+      return true;
+    }
+
+    foreach (array_map(null, $oldChangesets, $newChangesets) as $changesetPair) {
+      [$oldChangeset, $newChangeset] = $changesetPair;
+
+      if ($oldChangeset->getFileType() != $newChangeset->getFileType()
+        || $oldChangeset->getChangeType() != $newChangeset->getChangeType()) {
+        return true;
+      }
+
+      if ($newChangeset->getFileType() != DifferentialChangeType::FILE_TEXT
+        || $newChangeset->getChangeType() != DifferentialChangeType::TYPE_CHANGE) {
+        // For all changes other than "text file updated", fall back to the
+        // Phabricator-native way of checking if the changesets are the same
+        if (!$newChangeset->hasSameEffectAs($oldChangeset)) {
+          return true;
+        }
+      }
+
+      // This an update to a text file. Let's only consider this changeset
+      // to have been "changed" if its individual modifications are different
+      // from the previous changeset.
+
+      $oldHunks = $oldChangeset->getHunks();
+      $newHunks = $newChangeset->getHunks();
+
+      if (count($oldHunks) != count($newHunks)) {
+        return true;
+      }
+
+      foreach (array_map(null, $oldHunks, $newHunks) as $hunkPair) {
+        [$oldHunk, $newHunk] = $hunkPair;
+        $oldLines = explode("\n", $oldHunk->getData());
+        $newLines = explode("\n", $newHunk->getData());
+
+        if (count($oldLines) != count($newLines)) {
+          return true;
+        }
+
+        foreach (array_map(null, $oldLines, $newLines) as $linePair) {
+          [$oldLine, $newLine] = $linePair;
+
+          if (($oldLine !== $newLine) && ((strlen($oldLine) && $oldLine[0] != " ") || (strlen($newLine) && $newLine[0] != " "))) {
+            // If the lines aren't equivalent, and one of the lines starts with
+            // a non-space (so, either a "+" or "-" for added/removed contents)
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+
   /**
    * @return EmailAffectedFile[]
    */


### PR DESCRIPTION
Determine if an "updated" event has caused differences in its changesets
by comparing against the previous diff's changesets.

Phabricator's `DifferentialChangeset->hasSameEffectAs(...)` function
compares the updated file's overall hash, which is great for most file
types (binary, image, etc).

However, for text files, we want to separate earlier-patch-changes from
current-patch-changes, and only send "revision-updated" emails for the
latter. We do this by comparing our two changesets, and only considering
them different if the "current-patch-line-changes" differ, ignoring
background changes to the file.