### PR TITLE
Bug 1754076: make `Request Uplift` interact with Bugzilla

### DIFF
--- a/moz-extensions/src/applications/transactions/commentaction/PhabricatorUpdateUpliftCommentAction.php
+++ b/moz-extensions/src/applications/transactions/commentaction/PhabricatorUpdateUpliftCommentAction.php
@@ -4,23 +4,20 @@ class PhabricatorUpdateUpliftCommentAction
   extends PhabricatorEditEngineCommentAction {
 
   public function getPHUIXControlType() {
-    return 'remarkup';
+    return 'form';
   }
 
   public function getPHUIXControlSpecification() {
     $value = $this->getValue();
 
-    if (empty($value)) {
+    if (empty($value) || $value == null) {
       $value = $this->getInitialValue();
     }
 
-    if (empty($value)) {
-      $value = null;
-    }
-
     return array(
-      'value' => pht($value),
+        'questions' => $value,
     );
+
   }
 
 }

--- a/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
+++ b/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
@@ -4,237 +4,238 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 /**
- * Extends Differential with a 'Uplift Request' field.
- */
+* Extends Differential with a 'Uplift Request' field.
+*/
 final class DifferentialUpliftRequestCustomField
-  extends DifferentialStoredCustomField {
+    extends DifferentialStoredCustomField {
 
-  // Questions for beta, with defaults.
-  const BETA_UPLIFT_FIELDS = array(
-    "User impact if declined" => "",
-    "Code covered by automated testing" => false,
-    "Fix verified in Nightly" => false,
-    "Needs manual QE test" => false,
-    "Steps to reproduce for manual QE testing" => "",
-    "Risk associated with taking this patch" => "",
-    "Explanation of risk level" => "",
-    "String changes made/needed" => "",
-  );
+    // Questions for beta, with defaults.
+    const BETA_UPLIFT_FIELDS = array(
+        "User impact if declined" => "",
+        "Code covered by automated testing" => false,
+        "Fix verified in Nightly" => false,
+        "Needs manual QE test" => false,
+        "Steps to reproduce for manual QE testing" => "",
+        "Risk associated with taking this patch" => "",
+        "Explanation of risk level" => "",
+        "String changes made/needed" => "",
+    );
 
-  // How each field is formatted in ReMarkup:
-  // a bullet point with text in bold.
-  const QUESTION_FORMATTING = "- **%s** %s";
+    // How each field is formatted in ReMarkup:
+    // a bullet point with text in bold.
+    const QUESTION_FORMATTING = "- **%s** %s";
 
-  private $proxy;
+    private $proxy;
 
-/* -(  Core Properties and Field Identity  )--------------------------------- */
+    /* -(  Core Properties and Field Identity  )--------------------------------- */
 
-  public function readValueFromRequest(AphrontRequest $request) {
-    $uplift_data = $request->getJSONMap($this->getFieldKey());
-    $this->setValue($uplift_data);
-  }
+    public function readValueFromRequest(AphrontRequest $request) {
+        $uplift_data = $request->getJSONMap($this->getFieldKey());
+        $this->setValue($uplift_data);
+    }
 
-  public function getFieldKey() {
-    return 'differential:uplift-request';
-  }
+    public function getFieldKey() {
+        return 'differential:uplift-request';
+    }
 
-  public function getFieldKeyForConduit() {
-    return 'uplift.request';
-  }
+    public function getFieldKeyForConduit() {
+        return 'uplift.request';
+    }
 
-  public function getFieldValue() {
-    return $this->getValue();
-  }
+    public function getFieldValue() {
+        return $this->getValue();
+    }
 
-  public function getFieldName() {
-    return pht('Uplift Request form');
-  }
+    public function getFieldName() {
+        return pht('Uplift Request form');
+    }
 
-  public function getFieldDescription() {
-    // Rendered in 'Config > Differential > differential.fields'
-    return pht('Renders uplift request form.');
-  }
+    public function getFieldDescription() {
+        // Rendered in 'Config > Differential > differential.fields'
+        return pht('Renders uplift request form.');
+    }
 
-  public function isFieldEnabled() {
-    return true;
-  }
+    public function isFieldEnabled() {
+        return true;
+    }
 
-  public function canDisableField() {
-    // Field can't be switched off in configuration
-    return false;
-  }
+    public function canDisableField() {
+        // Field can't be switched off in configuration
+        return false;
+    }
 
-/* -(  ApplicationTransactions  )-------------------------------------------- */
+    /* -(  ApplicationTransactions  )-------------------------------------------- */
 
-  public function shouldAppearInApplicationTransactions() {
-    // Required to be editable
-    return true;
-  }
+    public function shouldAppearInApplicationTransactions() {
+        // Required to be editable
+        return true;
+    }
 
-  /* Set QE required flag on the relevant Bugzilla bug. */
-  public function setManualQERequiredFlag(int $bug) {
-    // Construct request for setting `qe-verify` flag, see
-    // https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
-    $url = id(new PhutilURI(PhabricatorEnv::getEnvConfig('bugzilla.url')))
-        ->setPath('/rest/bug/'.$bug);
-    $api_key = PhabricatorEnv::getEnvConfig('bugzilla.automation_api_key');
+    /* Set QE required flag on the relevant Bugzilla bug. */
+    public function setManualQERequiredFlag(int $bug) {
+        // Construct request for setting `qe-verify` flag, see
+        // https://bmo.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
+        $url = id(new PhutilURI(PhabricatorEnv::getEnvConfig('bugzilla.url')))
+            ->setPath('/rest/bug/'.$bug);
+        $api_key = PhabricatorEnv::getEnvConfig('bugzilla.automation_api_key');
 
-    // Encode here because `setData` below will fail due to nested arrays.
-    $data = phutil_json_encode(
-        array(
-            'flags' => array(
-                array(
-                    'name' => 'qe-verify',
-                    'status' => '?',
+        // Encode here because `setData` below will fail due to nested arrays.
+        $data = phutil_json_encode(
+            array(
+                'flags' => array(
+                    array(
+                        'name' => 'qe-verify',
+                        'status' => '?',
+                    ),
                 ),
             ),
-        ),
-    );
-
-    $future = id(new HTTPSFuture($url))
-        ->addHeader('Accept', 'application/json')
-        ->addHeader('Content-Type', 'application/json')
-        ->addHeader('User-Agent', 'Phabricator')
-        ->addHeader('X-Bugzilla-API-Key', $api_key)
-        ->setData($data)
-        ->setMethod('PUT')
-        ->setTimeout(PhabricatorEnv::getEnvConfig('bugzilla.timeout'));
-
-    try {
-      list($status, $body) = $future->resolve();
-      $status_code = (int) $status->getStatusCode();
-
-      # Return an error string and invalidate transaction if Bugzilla can't be contacted.
-        $body = phutil_json_decode($body);
-      if (array_key_exists("error", $body) && $body["error"]) {
-        throw new Exception(
-            'Could not set `qe-verify` on Bugzilla: status code: '.$status_code.'! Please file a bug.'
         );
-      }
 
-    } catch (PhutilJSONParserException $ex) {
-        throw new Exception(
-            'Expected invalid JSON response from BMO while setting `qe-verify` flag.'
-        );
-    }
-  }
+        $future = id(new HTTPSFuture($url))
+            ->addHeader('Accept', 'application/json')
+            ->addHeader('Content-Type', 'application/json')
+            ->addHeader('User-Agent', 'Phabricator')
+            ->addHeader('X-Bugzilla-API-Key', $api_key)
+            ->setData($data)
+            ->setMethod('PUT')
+            ->setTimeout(PhabricatorEnv::getEnvConfig('bugzilla.timeout'));
 
-  /* Comment the uplift request form on the relevant Bugzilla bug. */
-  public function commentUpliftOnBugzilla(int $bug) {
-    // Construct request for leaving a comment, see
-    // https://bmo.readthedocs.io/en/latest/api/core/v1/comment.html#create-comments
-    $url = id(new PhutilURI(PhabricatorEnv::getEnvConfig('bugzilla.url')))
-        ->setPath('/rest/bug/'.$bug.'/comment');
-    $api_key = PhabricatorEnv::getEnvConfig('bugzilla.automation_api_key');
+        try {
+            list($status, $body) = $future->resolve();
+            $status_code = (int) $status->getStatusCode();
 
-    $data = array(
-      'comment' => $this->getRemarkup(),
-      'is_markdown' => true,
-      'is_private' => false,
-    );
+            # Return an error string and invalidate transaction if Bugzilla can't be contacted.
+            $body = phutil_json_decode($body);
+            if (array_key_exists("error", $body) && $body["error"]) {
+                throw new Exception(
+                    'Could not set `qe-verify` on Bugzilla: status code: '.$status_code.'! Please file a bug.'
+                );
+            }
 
-    $future = id(new HTTPSFuture($url))
-        ->addHeader('Accept', 'application/json')
-        ->addHeader('User-Agent', 'Phabricator')
-        ->addHeader('X-Bugzilla-API-Key', $api_key)
-        ->setData($data)
-        ->setMethod('POST')
-        ->setTimeout(PhabricatorEnv::getEnvConfig('bugzilla.timeout'));
-
-    try {
-      list($status, $body) = $future->resolve();
-      $status_code = (int) $status->getStatusCode();
-
-      # Return an error string and invalidate transaction if Bugzilla can't be contacted.
-        $body = phutil_json_decode($body);
-        if (array_key_exists("error", $body) && $body["error"]) {
+        } catch (PhutilJSONParserException $ex) {
             throw new Exception(
-                'Could not leave a comment on Bugzilla: status code '.$status_code.'! Please file a bug.',
+                'Expected invalid JSON response from BMO while setting `qe-verify` flag.'
             );
         }
+    }
 
-    } catch (PhutilJSONParserException $ex) {
-        throw new Exception(
-            'Received invalid JSON response from BMO while leaving a comment.'
+    /* Comment the uplift request form on the relevant Bugzilla bug. */
+    public function commentUpliftOnBugzilla(int $bug) {
+        // Construct request for leaving a comment, see
+        // https://bmo.readthedocs.io/en/latest/api/core/v1/comment.html#create-comments
+        $url = id(new PhutilURI(PhabricatorEnv::getEnvConfig('bugzilla.url')))
+            ->setPath('/rest/bug/'.$bug.'/comment');
+        $api_key = PhabricatorEnv::getEnvConfig('bugzilla.automation_api_key');
+
+        $data = array(
+            'comment' => $this->getRemarkup(),
+            'is_markdown' => true,
+            'is_private' => false,
         );
+
+        $future = id(new HTTPSFuture($url))
+            ->addHeader('Accept', 'application/json')
+            ->addHeader('User-Agent', 'Phabricator')
+            ->addHeader('X-Bugzilla-API-Key', $api_key)
+            ->setData($data)
+            ->setMethod('POST')
+            ->setTimeout(PhabricatorEnv::getEnvConfig('bugzilla.timeout'));
+
+        try {
+            list($status, $body) = $future->resolve();
+            $status_code = (int) $status->getStatusCode();
+
+            # Return an error string and invalidate transaction if Bugzilla can't be contacted.
+            $body = phutil_json_decode($body);
+            if (array_key_exists("error", $body) && $body["error"]) {
+                throw new Exception(
+                    'Could not leave a comment on Bugzilla: status code '.$status_code.'! Please file a bug.',
+                );
+            }
+
+        } catch (PhutilJSONParserException $ex) {
+            throw new Exception(
+                'Received invalid JSON response from BMO while leaving a comment.'
+            );
+        }
     }
-  }
 
-/* -(  Edit View  )---------------------------------------------------------- */
+    /* -(  Edit View  )---------------------------------------------------------- */
 
-  public function shouldAppearInEditView() {
-    // Should the field appear in Edit Revision feature
-    return true;
-  }
-
-  // How the uplift text is rendered in the "Details" section.
-  public function renderPropertyViewValue(array $handles) {
-    if (empty($this->getValue())) {
-      return null;
+    public function shouldAppearInEditView() {
+        // Should the field appear in Edit Revision feature
+        return true;
     }
 
-    return new PHUIRemarkupView($this->getViewer(), $this->getRemarkup());
-  }
+    // How the uplift text is rendered in the "Details" section.
+    public function renderPropertyViewValue(array $handles) {
+        if (empty($this->getValue())) {
+            return null;
+        }
 
-  // How the field can be edited in the "Edit Revision" menu.
-  public function renderEditControl(array $handles) {
-    if (!$this->isUpliftTagSet()) {
-        return null; 
+        return new PHUIRemarkupView($this->getViewer(), $this->getRemarkup());
     }
 
-    return id(new PhabricatorRemarkupControl())
-      ->setLabel($this->getFieldName())
-      ->setCaption(pht('Please answer all questions.'))
-      ->setName($this->getFieldKey())
-      ->setValue($this->getRemarkup(), '');
-  }
+    // How the field can be edited in the "Edit Revision" menu.
+    public function renderEditControl(array $handles) {
+        if (!$this->isUpliftTagSet()) {
+            return null; 
+        }
 
-  // -- Comment action things
+        return id(new PhabricatorRemarkupControl())
+            ->setLabel($this->getFieldName())
+            ->setCaption(pht('Please answer all questions.'))
+            ->setName($this->getFieldKey())
+            ->setValue($this->getRemarkup(), '');
+    }
 
-  public function getCommentActionLabel() {
-    return pht('Request Uplift');
-  }
+    // -- Comment action things
 
-  // Return `true` if the `uplift` tag is set on the repository belonging to
-  // this revision.
-  private function isUpliftTagSet() {
-    $revision = $this->getObject();
-    $viewer = $this->getViewer();
+    public function getCommentActionLabel() {
+        return pht('Request Uplift');
+    }
 
-    if ($revision == null || $viewer == null) {
+    // Return `true` if the `uplift` tag is set on the repository belonging to
+    // this revision.
+    private function isUpliftTagSet() {
+        $revision = $this->getObject();
+        $viewer = $this->getViewer();
+
+        if ($revision == null || $viewer == null) {
+            return false;
+        }
+
+        try {
+            $repository_projects = PhabricatorEdgeQuery::loadDestinationPHIDs(
+                $revision->getFieldValuesForConduit()['repositoryPHID'],
+                PhabricatorProjectObjectHasProjectEdgeType::EDGECONST
+            );
+        } catch (Exception $e) {
+            return false;
+        }
+
+        if (!(bool)$repository_projects) {
+            return false;
+        }
+
+        $uplift_project = id(new PhabricatorProjectQuery())
+            ->setViewer($viewer)
+            ->withNames(array('uplift'))
+            ->executeOne();
+
+        // The `uplift` project isn't created or can't be found.
+        if (!(bool)$uplift_project) {
+            return false;
+        }
+
+        // If the `uplift` project PHID is in the set of all project PHIDs
+        // attached to the repo, return `true`.
+        if (in_array($uplift_project->getPHID(), $repository_projects)) {
+            return true;
+        }
+
         return false;
     }
-
-    try {
-        $repository_projects = PhabricatorEdgeQuery::loadDestinationPHIDs(
-          $revision->getFieldValuesForConduit()['repositoryPHID'],
-          PhabricatorProjectObjectHasProjectEdgeType::EDGECONST);
-    } catch (Exception $e) {
-      return false;
-    }
-
-    if (!(bool)$repository_projects) {
-      return false;
-    }
-
-    $uplift_project = id(new PhabricatorProjectQuery())
-      ->setViewer($viewer)
-      ->withNames(array('uplift'))
-      ->executeOne();
-
-    // The `uplift` project isn't created or can't be found.
-    if (!(bool)$uplift_project) {
-        return false;
-    }
-
-    // If the `uplift` project PHID is in the set of all project PHIDs
-    // attached to the repo, return `true`.
-    if (in_array($uplift_project->getPHID(), $repository_projects)) {
-      return true;
-    }
-
-    return false;
-  }
 
     // Convert `bool` types to readable text, or return base text.
     private function valueAsAnswer($value): string {
@@ -247,122 +248,122 @@ final class DifferentialUpliftRequestCustomField
         }
     }
 
-  private function getRemarkup(): string {
-      $questions = array();
+    private function getRemarkup(): string {
+        $questions = array();
 
-      $value = $this->getValue();
-      foreach ($value as $question => $answer) {
-          $answer_readable = $this->valueAsAnswer($answer);
-          $questions[] = sprintf(
-              self::QUESTION_FORMATTING, $question, $answer_readable
-          );
-      }
-
-      return implode("\n", $questions);
-  }
-
-  public function newCommentAction() {
-    // Returning `null` causes no comment action to render, effectively
-    // "disabling" the field.
-    if (!$this->isUpliftTagSet()) {
-        return null;
-    }
-
-    $action = id(new PhabricatorUpdateUpliftCommentAction())
-      ->setConflictKey('revision.action')
-      ->setValue($this->getValue())
-      ->setInitialValue(self::BETA_UPLIFT_FIELDS)
-      ->setSubmitButtonText(pht('Request Uplift'));
-
-    return $action;
-  }
-
-  public function validateUpliftForm(array $form): array {
-    $validation_errors = array();
-
-    # Allow clearing the form.
-    if (empty($form)) {
-      return $validation_errors;
-    }
-
-    foreach($form as $question => $answer) {
-        // `empty(false)` is `true` so handle `bool` separately.
-        if (is_bool($answer)) {
-            continue;
+        $value = $this->getValue();
+        foreach ($value as $question => $answer) {
+            $answer_readable = $this->valueAsAnswer($answer);
+            $questions[] = sprintf(
+                self::QUESTION_FORMATTING, $question, $answer_readable
+            );
         }
 
-        if (empty($answer)) {
-            $validation_errors[] = "Need to answer '$question'";
+        return implode("\n", $questions);
+    }
+
+    public function newCommentAction() {
+        // Returning `null` causes no comment action to render, effectively
+        // "disabling" the field.
+        if (!$this->isUpliftTagSet()) {
+            return null;
         }
+
+        $action = id(new PhabricatorUpdateUpliftCommentAction())
+            ->setConflictKey('revision.action')
+            ->setValue($this->getValue())
+            ->setInitialValue(self::BETA_UPLIFT_FIELDS)
+            ->setSubmitButtonText(pht('Request Uplift'));
+
+        return $action;
     }
 
-    return $validation_errors;
-  }
+    public function validateUpliftForm(array $form): array {
+        $validation_errors = array();
 
-  public function qeRequired() {
-    return $this->getValue()['Needs manual QE test'];
-  }
+        # Allow clearing the form.
+        if (empty($form)) {
+            return $validation_errors;
+        }
 
-  public function validateApplicationTransactions(
-    PhabricatorApplicationTransactionEditor $editor,
-    $type, array $xactions) {
+        foreach($form as $question => $answer) {
+            // `empty(false)` is `true` so handle `bool` separately.
+            if (is_bool($answer)) {
+                continue;
+            }
 
-    $errors = parent::validateApplicationTransactions($editor, $type, $xactions);
+            if (empty($answer)) {
+                $validation_errors[] = "Need to answer '$question'";
+            }
+        }
 
-    $field_is_empty = true;
-    foreach($xactions as $xaction) {
-      // We can skip validation if the field is empty.
-      $new_value = $xaction->getNewValue();
-      if (!empty($new_value)) {
-        $field_is_empty = false;
-        continue;
-      }
-
-      // Validate that the form is correctly filled out.
-      // This should always be a string (think if the value came from the remarkup edit)
-      $validation_errors = $this->validateUpliftForm(
-        phutil_json_decode($xaction->getNewValue()),
-      );
-
-      // Push errors into the revision save stack
-      foreach($validation_errors as $validation_error) {
-        $errors[] = new PhabricatorApplicationTransactionValidationError(
-          $type,
-          '',
-          pht($validation_error)
-        );
-      }
+        return $validation_errors;
     }
 
-    // No need to check for a bug if we haven't submitted the form, or are clearing it.
-    if ($field_is_empty) {
+    public function qeRequired() {
+        return $this->getValue()['Needs manual QE test'];
+    }
+
+    public function validateApplicationTransactions(
+        PhabricatorApplicationTransactionEditor $editor,
+        $type, array $xactions) {
+
+        $errors = parent::validateApplicationTransactions($editor, $type, $xactions);
+
+        $field_is_empty = true;
+        foreach($xactions as $xaction) {
+            // We can skip validation if the field is empty.
+            $new_value = $xaction->getNewValue();
+            if (!empty($new_value)) {
+                $field_is_empty = false;
+                continue;
+            }
+
+            // Validate that the form is correctly filled out.
+            // This should always be a string (think if the value came from the remarkup edit)
+            $validation_errors = $this->validateUpliftForm(
+                phutil_json_decode($xaction->getNewValue()),
+            );
+
+            // Push errors into the revision save stack
+            foreach($validation_errors as $validation_error) {
+                $errors[] = new PhabricatorApplicationTransactionValidationError(
+                    $type,
+                    '',
+                    pht($validation_error)
+                );
+            }
+        }
+
+        // No need to check for a bug if we haven't submitted the form, or are clearing it.
+        if ($field_is_empty) {
+            return $errors;
+        }
+
+        // Similar idea to `BugStore::resolveBug`.
+        $bugzillaField = new DifferentialBugzillaBugIDField();
+        $bugzillaField->setObject($this->getObject());
+        (new PhabricatorCustomFieldStorageQuery())
+            ->addField($bugzillaField)
+            ->execute();
+        $bug = $bugzillaField->getValue();
+
+        // Assert we have a bug attached to the revision.
+        if (!$bug) {
+            $errors[] = new PhabricatorApplicationTransactionValidationError(
+                $type,
+                '',
+                pht("Can't submit an uplift request without a bug."),
+            );
+        }
+
         return $errors;
     }
 
-    // Similar idea to `BugStore::resolveBug`.
-    $bugzillaField = new DifferentialBugzillaBugIDField();
-    $bugzillaField->setObject($this->getObject());
-    (new PhabricatorCustomFieldStorageQuery())
-      ->addField($bugzillaField)
-      ->execute();
-    $bug = $bugzillaField->getValue();
-
-    // Assert we have a bug attached to the revision.
-    if (!$bug) {
-        $errors[] = new PhabricatorApplicationTransactionValidationError(
-            $type,
-            '',
-            pht("Can't submit an uplift request without a bug."),
-        );
-    }
-
-    return $errors;
-  }
-
-  // Update Bugzilla when applying effects.
-  public function applyApplicationTransactionExternalEffects(
-    PhabricatorApplicationTransaction $xaction
-  ) {
+    // Update Bugzilla when applying effects.
+    public function applyApplicationTransactionExternalEffects(
+        PhabricatorApplicationTransaction $xaction
+    ) {
         $ret = parent::applyApplicationTransactionExternalEffects($xaction);
 
         // Similar idea to `BugStore::resolveBug`.
@@ -370,8 +371,8 @@ final class DifferentialUpliftRequestCustomField
         $bugzillaField = new DifferentialBugzillaBugIDField();
         $bugzillaField->setObject($this->getObject());
         (new PhabricatorCustomFieldStorageQuery())
-          ->addField($bugzillaField)
-          ->execute();
+            ->addField($bugzillaField)
+            ->execute();
         $bug = $bugzillaField->getValue();
 
         // Always comment the uplift form.
@@ -383,96 +384,96 @@ final class DifferentialUpliftRequestCustomField
         }
 
         return $ret;
-  }
-
-  // When storing the value convert the question => answer mapping to a JSON string.
-  public function getValueForStorage(): string {
-    return phutil_json_encode($this->getValue());
-  }
-
-  public function setValueFromStorage($value) {
-    try {
-      $this->setValue(phutil_json_decode($value));
-    } catch (PhutilJSONParserException $ex) {
-      $this->setValue(array());
     }
-    return $this;
-  }
 
-  public function setValueFromApplicationTransactions($value) {
-    $this->setValue($value);
-    return $this;
-  }
+    // When storing the value convert the question => answer mapping to a JSON string.
+    public function getValueForStorage(): string {
+        return phutil_json_encode($this->getValue());
+    }
 
-  public function setValue($value) {
+    public function setValueFromStorage($value) {
+        try {
+            $this->setValue(phutil_json_decode($value));
+        } catch (PhutilJSONParserException $ex) {
+            $this->setValue(array());
+        }
+        return $this;
+    }
+
+    public function setValueFromApplicationTransactions($value) {
+        $this->setValue($value);
+        return $this;
+    }
+
+    public function setValue($value) {
         if (!is_array($value)) {
             parent::setValue(phutil_json_decode($value));
         } else {
             parent::setValue($value);
         }
-  }
-
-
-/* -(  Property View  )------------------------------------------------------ */
-
-  public function shouldAppearInPropertyView() {
-    return true;
-  }
-
-/* -(  Global Search  )------------------------------------------------------ */
-
-  public function shouldAppearInGlobalSearch() {
-    return true;
-  }
-
-/* -(  Conduit  )------------------------------------------------------------ */
-
-  public function shouldAppearInConduitDictionary() {
-    // Should the field appear in `differential.revision.search`
-    return true;
-  }
-
-  public function shouldAppearInConduitTransactions() {
-    // Required if needs to be saved via Conduit (i.e. from `arc diff`)
-    return true;
-  }
-
-  protected function newConduitSearchParameterType() {
-    return new ConduitStringParameterType();
-  }
-
-  protected function newConduitEditParameterType() {
-    // Define the type of the parameter for Conduit
-    return new ConduitStringParameterType();
-  }
-
-  public function readFieldValueFromConduit(string $value) {
-    return $value;
-  }
-
-  public function isFieldEditable() {
-    // Has to be editable to be written from `arc diff`
-    return true;
-  }
-
-  public function shouldDisableByDefault() {
-    return false;
-  }
-
-  public function shouldOverwriteWhenCommitMessageIsEdited() {
-    return false;
-  }
-
-  public function getApplicationTransactionTitle(
-    PhabricatorApplicationTransaction $xaction) {
-
-    if($this->proxy) {
-      return $this->proxy->getApplicationTransactionTitle($xaction);
     }
 
-    $author_phid = $xaction->getAuthorPHID();
 
-    return pht('%s updated the uplift request field.', $xaction->renderHandleLink($author_phid));
-  }
+    /* -(  Property View  )------------------------------------------------------ */
+
+    public function shouldAppearInPropertyView() {
+        return true;
+    }
+
+    /* -(  Global Search  )------------------------------------------------------ */
+
+    public function shouldAppearInGlobalSearch() {
+        return true;
+    }
+
+    /* -(  Conduit  )------------------------------------------------------------ */
+
+    public function shouldAppearInConduitDictionary() {
+        // Should the field appear in `differential.revision.search`
+        return true;
+    }
+
+    public function shouldAppearInConduitTransactions() {
+        // Required if needs to be saved via Conduit (i.e. from `arc diff`)
+        return true;
+    }
+
+    protected function newConduitSearchParameterType() {
+        return new ConduitStringParameterType();
+    }
+
+    protected function newConduitEditParameterType() {
+        // Define the type of the parameter for Conduit
+        return new ConduitStringParameterType();
+    }
+
+    public function readFieldValueFromConduit(string $value) {
+        return $value;
+    }
+
+    public function isFieldEditable() {
+        // Has to be editable to be written from `arc diff`
+        return true;
+    }
+
+    public function shouldDisableByDefault() {
+        return false;
+    }
+
+    public function shouldOverwriteWhenCommitMessageIsEdited() {
+        return false;
+    }
+
+    public function getApplicationTransactionTitle(
+        PhabricatorApplicationTransaction $xaction) {
+
+        if($this->proxy) {
+            return $this->proxy->getApplicationTransactionTitle($xaction);
+        }
+
+        $author_phid = $xaction->getAuthorPHID();
+
+        return pht('%s updated the uplift request field.', $xaction->renderHandleLink($author_phid));
+    }
 }
 

--- a/webroot/rsrc/js/phuix/PHUIXFormControl.js
+++ b/webroot/rsrc/js/phuix/PHUIXFormControl.js
@@ -61,6 +61,9 @@ JX.install('PHUIXFormControl', {
         case 'remarkup':
           input = this._newRemarkup(spec);
           break;
+        case 'form':
+          input = this._newForm(spec);
+          break;
         default:
           // TODO: Default or better error?
           JX.$E('Bad Input Type');
@@ -342,6 +345,79 @@ JX.install('PHUIXFormControl', {
           node.value = value;
         }
       };
+    },
+
+    // Render a sub-form within the form control space.
+    // Takes a spec of fields and their answer formats and returns
+    // a mapping of fields to values.
+    _newForm: function(spec) {
+        //var questions_parsed = JX.JSON.parse(spec.questions);
+        var questions_parsed = spec.questions;
+
+        var questions = [];
+        var question_list = [];
+        for (const question in questions_parsed) {
+            var question_id = 'question-' + Math.floor(Math.random() * 1000000);
+            var value = questions_parsed[question];
+
+            // Determine input format, either a bool or a text value.
+            var value_type = typeof (value);
+            var input_type;
+            if (value_type == "string") {
+                input_type = "textarea";
+            } else if (value_type == "boolean") {
+                input_type = "checkbox";
+            }
+
+            var question_obj = JX.$N(
+              'input',
+              {
+                type: input_type,
+                value: value,
+                id: question_id,
+                question: question,
+              });
+
+            questions.push(question_obj);
+
+            var label = JX.$N(
+              'label',
+              {
+                className: 'phuix-form-checkbox-label',
+                htmlFor: question_id,
+              },
+              JX.$H(question || ''));
+
+            var display = JX.$N(
+              'div', {
+                className: 'phuix-form-checkbox-item'
+              },
+              [question_obj, label]);
+
+            question_list.push(display);
+        }
+
+        var node = JX.$N('div', {}, question_list);
+
+        return {
+            node: node,
+            get: function () {
+                var map = {};
+                for (var ii = 0; ii < questions.length; ii++) {
+                    var question_obj = questions[ii];
+
+                    if (question_obj.type == "checkbox") {
+                        map[question_obj.question] = question_obj.checked;
+                    } else {
+                        map[question_obj.question] = question_obj.value;
+                    }
+                }
+
+                return map;
+            },
+            // `set` is never called.
+            set: function (_value) {},
+        };
     },
 
     _newOptgroups: function(spec) {


### PR DESCRIPTION
This commit adds interactions with Bugzilla when submitting an
uplift request form on Phabricator. To do this we change the
uplift request comment action from a standard textarea populated
with remarkup for the entire request, into a form with inputs
for each question in the form. We add a custom `form` PHUIXControlType
which takes a spec with a single `questions` field to populate
the values in the form.

We change the type of `DifferentialUpliftRequestCustomField::value`
from a string to a mapping array in all usages, and only convert
the mapping to a string when modifying and accessing from internal
storage. The beta uplift questions array is changed to a mapping of
`questions => defaults` for initial form population. We add a function
`getRemarkup` which converts the field mapping values into a nicely
formatted Remarkup/Markdown string.

Since the above changes allow us to access form fields individually
as typed values, we can now make decisions based on the results of
inputs in the form. We add a code path to interact with Bugzilla
when applying transaction effects (ie saving the new result to
storage). We add a remarkup comment to Bugzilla on the relevant
bug and set the `qe-verify` flag if the user indicated manual QE
testing is required.
