### PR TITLE
Bug 1758000: decode `repo.root` to `str` before passing to `Path`

### DIFF
--- a/hgext/differentiator.py
+++ b/hgext/differentiator.py
@@ -21,8 +21,12 @@ phabricator_uri = os.getenvb(b"PHABRICATOR_URI")
 
 
 def get_local_repo_callsign(repo) -> str:
-    """Returns the callsign from the local repository's `.arcconfig` file."""
-    repo_path = pathlib.Path(repo.root)
+    """Returns the callsign for the local repo parsed from the path.
+
+    Uses the repository root path name as the repository ID and returns
+    the corresponding repository callsign from conduit.
+    """
+    repo_path = pathlib.Path(repo.root.decode("utf-8"))
     repo_id = int(repo_path.name)
 
     # Search Conduit for all repositories.
@@ -37,7 +41,7 @@ def get_local_repo_callsign(repo) -> str:
         if repo_id == repo_object["id"]:
             return repo_object["fields"]["callsign"]
 
-    raise error.Abort(b"No repo found with ID %s" % repo_id)
+    raise error.Abort(b"No repo found with ID %d" % repo_id)
 
 
 def call_conduit(method: str, params: dict) -> dict:

--- a/hgext/differentiator.py
+++ b/hgext/differentiator.py
@@ -33,7 +33,7 @@ def get_local_repo_callsign(repo) -> str:
     response = call_conduit("diffusion.repository.search", {})
 
     # Retrieve the repo objects.
-    repo_objects = response["response"]["data"]
+    repo_objects = response["result"]["data"]
 
     for repo_object in repo_objects:
         # If the repo ID we parsed from the working directory matches the


### PR DESCRIPTION
`pathlib` doesn't work with bytes paths, so we need to decode
`repo.root` before creating the `Path` object.

While we are here, update the docstring to reflect the new
behaviour of the function and use the correct `%d` string
formatting operator.
