### PR TITLE
Bug 1764136: improve styling of uplift request form

### DIFF
--- a/moz-extensions/src/applications/transactions/commentaction/PhabricatorUpdateUpliftCommentAction.php
+++ b/moz-extensions/src/applications/transactions/commentaction/PhabricatorUpdateUpliftCommentAction.php
@@ -9,12 +9,15 @@ class PhabricatorUpdateUpliftCommentAction
 
   public function getPHUIXControlSpecification() {
     $value = $this->getValue();
+    $initial = false;
 
     if (empty($value) || $value == null) {
       $value = $this->getInitialValue();
+      $initial = true;
     }
 
     return array(
+        'initial' => $initial,
         'questions' => $value,
     );
 

--- a/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
+++ b/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
@@ -309,17 +309,20 @@ final class DifferentialUpliftRequestCustomField
                 continue;
             }
 
-            # Assert the type from the response matches the type of the default.
             $default_type = gettype(self::BETA_UPLIFT_FIELDS[$question]);
-            $answer_type = gettype($answer);
-            if ($default_type != $answer_type) {
-                $validation_errors[] = "Parsing error: type '$answer_type' for '$question' doesn't match expected '$default_type'!";
+
+            # Assert the value is not empty.
+            $empty_string = $default_type == "string" && empty($answer);
+            $null_bool = $default_type == "boolean" && is_null($answer);
+            if ($empty_string || $null_bool) {
+                $validation_errors[] = "Need to answer '$question'";
                 continue;
             }
 
-            # Assert the value is not empty.
-            if ($default_type == "string" && empty($answer)) {
-                $validation_errors[] = "Need to answer '$question'";
+            # Assert the type from the response matches the type of the default.
+            $answer_type = gettype($answer);
+            if ($default_type != $answer_type) {
+                $validation_errors[] = "Parsing error: type '$answer_type' for '$question' doesn't match expected '$default_type'!";
                 continue;
             }
 
@@ -328,12 +331,11 @@ final class DifferentialUpliftRequestCustomField
 
         # Make sure we have all the required fields present in the response.
         $missing = array_diff($valid_questions, $validated_question);
-        if ($missing) {
+        if (empty($validation_errors) && $missing) {
             foreach($missing as $missing_question) {
                 $validation_errors[] = "Missing response for $missing_question";
             }
         }
-
 
         return $validation_errors;
     }

--- a/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
+++ b/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
@@ -299,22 +299,47 @@ final class DifferentialUpliftRequestCustomField
             return $validation_errors;
         }
 
+        $valid_questions = array_keys(self::BETA_UPLIFT_FIELDS);
+
+        $validated_question = array();
         foreach($form as $question => $answer) {
-            // `empty(false)` is `true` so handle `bool` separately.
-            if (is_bool($answer)) {
+            # Assert the question is valid.
+            if (!in_array($question, $valid_questions)) {
+                $validation_errors[] = "Invalid question: '$question'";
                 continue;
             }
 
-            if (empty($answer)) {
+            # Assert the type from the response matches the type of the default.
+            $default_type = gettype(self::BETA_UPLIFT_FIELDS[$question]);
+            $answer_type = gettype($answer);
+            if ($default_type != $answer_type) {
+                $validation_errors[] = "Parsing error: type '$answer_type' for '$question' doesn't match expected '$default_type'!";
+                continue;
+            }
+
+            # Assert the value is not empty.
+            if ($default_type == "string" && empty($answer)) {
                 $validation_errors[] = "Need to answer '$question'";
+                continue;
+            }
+
+            $validated_question[] = $question;
+        }
+
+        # Make sure we have all the required fields present in the response.
+        $missing = array_diff($valid_questions, $validated_question);
+        if ($missing) {
+            foreach($missing as $missing_question) {
+                $validation_errors[] = "Missing response for $missing_question";
             }
         }
+
 
         return $validation_errors;
     }
 
     public function qeRequired() {
-        return $this->getValue()['Needs manual QE test'];
+        return $this->getValue()['Needs manual QE test'] === true;
     }
 
     public function validateApplicationTransactions(

--- a/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
+++ b/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
@@ -278,7 +278,7 @@ final class DifferentialUpliftRequestCustomField
     public function newCommentAction() {
         // Returning `null` causes no comment action to render, effectively
         // "disabling" the field.
-        if (!$this->isUpliftTagSet()) {
+        if (!$this->isFieldActive()) {
             return null;
         }
 

--- a/webroot/rsrc/css/phui/phui-form-view.css
+++ b/webroot/rsrc/css/phui/phui-form-view.css
@@ -557,6 +557,32 @@ properly, and submit values. */
   margin-left: 4px;
 }
 
+.phuix-form-form-row {
+  margin: 2px;
+  display: table-row;
+}
+
+.phuix-form-form-label {
+  margin: 2px;
+  display: table-cell;
+}
+
+.phuix-form-form-textarea {
+  width: auto;
+  margin-left: 4px;
+  vertical-align: middle;
+  display: table-cell;
+}
+
+.phuix-form-form-select {
+  margin: 2px;
+  display: table-cell;
+}
+
+.phuix-form-form-table {
+  display: table;
+}
+
 .phui-form-timer-icon {
   width: 28px;
   height: 28px;

--- a/webroot/rsrc/js/phuix/PHUIXFormControl.js
+++ b/webroot/rsrc/js/phuix/PHUIXFormControl.js
@@ -351,7 +351,6 @@ JX.install('PHUIXFormControl', {
     // Takes a spec of fields and their answer formats and returns
     // a mapping of fields to values.
     _newForm: function(spec) {
-        //var questions_parsed = JX.JSON.parse(spec.questions);
         var questions_parsed = spec.questions;
 
         var questions = [];
@@ -362,42 +361,54 @@ JX.install('PHUIXFormControl', {
 
             // Determine input format, either a bool or a text value.
             var value_type = typeof (value);
-            var input_type;
-            if (value_type == "string") {
-                input_type = "textarea";
-            } else if (value_type == "boolean") {
-                input_type = "checkbox";
-            }
 
-            var question_obj = JX.$N(
-              'input',
-              {
-                type: input_type,
-                value: value,
-                id: question_id,
-                question: question,
+            var question_obj;
+            if (value_type == "string") {
+              question_obj = JX.$N(
+                'input',
+                {
+                  className: 'aphront-form-control phuix-form-form-textarea',
+                  type: 'textarea',
+                  value: value,
+                  id: question_id,
+                  question: question,
               });
+            } else if (value_type == "boolean") {
+                var options = [];
+
+                options.push(JX.$N('option', {value: 'yes'}, 'Yes'));
+                options.push(JX.$N('option', {value: 'no'}, 'No'));
+
+                question_obj = JX.$N('select', {
+                    className: 'phuix-form-form-select',
+                    id: question_id,
+                    question: question,
+                    value: value,
+                }, options);
+            }
 
             questions.push(question_obj);
 
             var label = JX.$N(
               'label',
               {
-                className: 'phuix-form-checkbox-label',
+                className: 'phuix-form-form-label',
                 htmlFor: question_id,
               },
               JX.$H(question || ''));
 
             var display = JX.$N(
               'div', {
-                className: 'phuix-form-checkbox-item'
+                className: 'phuix-form-form-row',
               },
-              [question_obj, label]);
+              [label, question_obj]);
 
             question_list.push(display);
         }
 
-        var node = JX.$N('div', {}, question_list);
+        var node = JX.$N('div', {
+            className: 'phui-form-view phui-form-form-table'
+        }, question_list);
 
         return {
             node: node,
@@ -406,8 +417,10 @@ JX.install('PHUIXFormControl', {
                 for (var ii = 0; ii < questions.length; ii++) {
                     var question_obj = questions[ii];
 
-                    if (question_obj.type == "checkbox") {
-                        map[question_obj.question] = question_obj.checked;
+                    // Convert "yes" and "no" to boolean.
+                    if (question_obj.type == "select-one") {
+                        var bool_value = (question_obj.value === 'yes');
+                        map[question_obj.question] = bool_value;
                     } else {
                         map[question_obj.question] = question_obj.value;
                     }

--- a/webroot/rsrc/js/phuix/PHUIXFormControl.js
+++ b/webroot/rsrc/js/phuix/PHUIXFormControl.js
@@ -347,11 +347,24 @@ JX.install('PHUIXFormControl', {
       };
     },
 
+    // Convert "true" and "false" strings to bool.
+    _boolValue: function(string_value) {
+        switch (string_value) {
+            case 'true':
+                return true;
+            case 'false':
+                return false;
+        }
+
+        return null;
+    },
+
     // Render a sub-form within the form control space.
     // Takes a spec of fields and their answer formats and returns
     // a mapping of fields to values.
     _newForm: function(spec) {
         var questions_parsed = spec.questions;
+        var initial = spec.initial;
 
         var questions = [];
         var question_list = [];
@@ -374,18 +387,25 @@ JX.install('PHUIXFormControl', {
                   question: question,
               });
             } else if (value_type == "boolean") {
-                var options = [];
-
-                options.push(JX.$N('option', {value: null}, '-- Select One --'));
-                options.push(JX.$N('option', {value: 'yes'}, 'Yes'));
-                options.push(JX.$N('option', {value: 'no'}, 'No'));
-
-                question_obj = JX.$N('select', {
-                    className: 'phuix-form-form-select',
-                    id: question_id,
-                    question: question,
-                    value: value,
-                }, options);
+                // Set "Select One" as the default.
+                if (initial) {
+                    value = null;
+                }
+                question_obj = JX.Prefab.renderSelect(
+                    {
+                        null: 'Select One',
+                        true: 'Yes',
+                        false: 'No',
+                    },
+                    value,
+                    {
+                        className: 'phuix-form-form-select',
+                        id: question_id,
+                        question: question,
+                        value: value,
+                    },
+                    [null, true, false]
+                );
             }
 
             questions.push(question_obj);
@@ -418,22 +438,10 @@ JX.install('PHUIXFormControl', {
                 for (var ii = 0; ii < questions.length; ii++) {
                     var question_obj = questions[ii];
 
-                    // Convert "yes" and "no" to boolean.
                     if (question_obj.type == "select-one") {
-                        var bool_value;
-                        switch (question_obj.value) {
-                            case 'yes':
-                                bool_value = true;
-                                break;
-                            case 'no':
-                                bool_value = false;
-                                break;
-                            default:
-                                bool_value = null;
-                                break;
-                        }
-
-                        map[question_obj.question] = bool_value;
+                        // Convert "true" and "false" string values to boolean.
+                        var bool_val = this._boolValue(question_obj.value);
+                        map[question_obj.question] = bool_val;
                     } else {
                         map[question_obj.question] = question_obj.value;
                     }

--- a/webroot/rsrc/js/phuix/PHUIXFormControl.js
+++ b/webroot/rsrc/js/phuix/PHUIXFormControl.js
@@ -376,6 +376,7 @@ JX.install('PHUIXFormControl', {
             } else if (value_type == "boolean") {
                 var options = [];
 
+                options.push(JX.$N('option', {value: null}, '-- Select One --'));
                 options.push(JX.$N('option', {value: 'yes'}, 'Yes'));
                 options.push(JX.$N('option', {value: 'no'}, 'No'));
 
@@ -419,7 +420,19 @@ JX.install('PHUIXFormControl', {
 
                     // Convert "yes" and "no" to boolean.
                     if (question_obj.type == "select-one") {
-                        var bool_value = (question_obj.value === 'yes');
+                        var bool_value;
+                        switch (question_obj.value) {
+                            case 'yes':
+                                bool_value = true;
+                                break;
+                            case 'no':
+                                bool_value = false;
+                                break;
+                            default:
+                                bool_value = null;
+                                break;
+                        }
+
                         map[question_obj.question] = bool_value;
                     } else {
                         map[question_obj.question] = question_obj.value;


### PR DESCRIPTION
Make the uplift request form use the `display: table` CSS
style to improve the appearance of the form. Change yes/no
answers in the form from a checkbox to a dropdown selection.
Add better validation of the form submission to server-side
processing.
