### PR TITLE
Bug 1765394: Remove extraneous "return false"

### DIFF
--- a/moz-extensions/src/email/resolve/ResolveCodeChange.php
+++ b/moz-extensions/src/email/resolve/ResolveCodeChange.php
@@ -75,7 +75,6 @@ class ResolveCodeChange {
           }
         }
       }
-      return false;
     }
     return false;
   }


### PR DESCRIPTION
The early `return false` was likely causing an email to be omitted if
the first changeset checked had no changes.