### PR TITLE
Bug 1772684 - Support Markdown style language syntax for fenced code block.

### DIFF
--- a/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
+++ b/src/infrastructure/markup/blockrule/PhutilRemarkupCodeBlockRule.php
@@ -44,7 +44,15 @@ final class PhutilRemarkupCodeBlockRule extends PhutilRemarkupBlockRule {
   }
 
   public function markupText($text, $children) {
-    if (preg_match('/^\s*```/', $text)) {
+    $fenced_lang = null;
+
+    $matches = [];
+    if (preg_match('/^\s*```(([a-z]+)\n)?/', $text, $matches)) {
+      // Detect the Markdown language syntax before trimming the blank lines.
+      if (count($matches) == 3 && $matches[2]) {
+        $fenced_lang = $matches[2];
+      }
+
       // If this is a ```-style block, trim off the backticks and any leading
       // blank line.
       $text = preg_replace('/^\s*```(\s*\n)?/', '', $text);
@@ -73,6 +81,13 @@ final class PhutilRemarkupCodeBlockRule extends PhutilRemarkupBlockRule {
           break;
         }
       }
+
+      if (!$valid && $fenced_lang) {
+        # Fallback to Markdown language syntax.
+        $valid = true;
+        $custom['lang'] = $fenced_lang;
+      }
+
       if ($valid) {
         array_shift($lines);
         $options = $custom + $options;


### PR DESCRIPTION
Phabricator uses remarkup for comment markup, and it supports `lang=cpp` style option to enable syntax highlighting for the fenced code block.

Bugzilla and Matrix uses markdown (or maybe variant?), and Searchfox has a feature to copy a code block with Markdown-style (https://bugzilla.mozilla.org/show_bug.cgi?id=1769936), that uses just `cpp` to specify the language.

This patch adds fallback path for the case that code block rule doesn't detect `lang=cpp` style options, to use the `cpp` style.

To avoid unexpected result, the fallback happens only when it's in the same line as the backticks, followed by newline.
