### PR TITLE
Bug 1681067 - Treat .h file as C++.

### DIFF
--- a/src/infrastructure/markup/syntax/highlighter/PhutilPygmentsSyntaxHighlighter.php
+++ b/src/infrastructure/markup/syntax/highlighter/PhutilPygmentsSyntaxHighlighter.php
@@ -114,7 +114,7 @@ final class PhutilPygmentsSyntaxHighlighter extends Phobject {
       'gemspec' => 'rb',
       'geo' => 'glsl',
       'GNUmakefile' => 'make',
-      'h' => 'c',
+      'h' => 'cpp',
       'h++' => 'cpp',
       'hh' => 'cpp',
       'hpp' => 'cpp',


### PR DESCRIPTION
in mozilla-central, in most case .h file is C++ code, and highlighting it as C++ code won't harm even if it's C code.