### PR TITLE
Bug 1472174 - Linkify the bug number in the commit message in the revision page.

### DIFF
--- a/src/applications/differential/controller/DifferentialRevisionViewController.php
+++ b/src/applications/differential/controller/DifferentialRevisionViewController.php
@@ -670,7 +670,7 @@ final class DifferentialRevisionViewController
 
   private function buildHeader(DifferentialRevision $revision) {
     $view = id(new PHUIHeaderView())
-      ->setHeader($revision->getTitle($revision))
+      ->setHeader($this->markupHeader($revision->getTitle()))
       ->setUser($this->getViewer())
       ->setPolicyObject($revision)
       ->setHeaderIcon('fa-cog');
@@ -700,6 +700,29 @@ final class DifferentialRevisionViewController
     }
 
     return $view;
+  }
+
+  private function markupHeader($text) {
+    $matches = [];
+    if (!preg_match('/^(bug\s*#?\s*(\d+))(.*)$/i', $text, $matches)) {
+      return $text;
+    }
+
+    $bug_text = $matches[1];
+    $bug = $matches[2];
+    $tail = $matches[3];
+
+    $uri = id(new PhutilURI(PhabricatorEnv::getEnvConfig('bugzilla.url')))
+        ->setPath('/show_bug.cgi')
+        ->setQueryParam('id', $bug);
+
+    return phutil_tag('span', array(), array(
+      phutil_tag('a', array(
+        'href' => $uri,
+        'class' => 'bug-number',
+      ), array($bug_text)),
+      $tail
+    ));
   }
 
   private function buildSubheaderView(DifferentialRevision $revision) {

--- a/webroot/rsrc/css/phui/phui-header-view.css
+++ b/webroot/rsrc/css/phui/phui-header-view.css
@@ -89,6 +89,14 @@ body .phui-header-shell.phui-bleed-header
   color: {$darkbluetext};
 }
 
+.phui-header-view .phui-header-header a.bug-number {
+  color: {$blue};
+}
+
+.phui-header-view .phui-header-header a.bug-number:hover {
+  text-decoration: underline !important;
+}
+
 .phui-box-blue-property .phui-header-view .phui-header-header a {
   color: {$bluetext};
 }


### PR DESCRIPTION
This is dirty hack that directly modifies the code that's not BMO-specific.
If this is not acceptable, I'll look into make it more generic, like comment markup.

Also, for some reason, a link in the header has almost same color as the header itself (`#464C5C` vs `#000000`),
and it's hard to notice it's a link, so I added extra rule to make the link more visible.
