### PR TITLE
Bug 1787517: include stack dependencies in revision

### DIFF
--- a/src/applications/differential/storage/DifferentialRevision.php
+++ b/src/applications/differential/storage/DifferentialRevision.php
@@ -1127,7 +1127,13 @@ final class DifferentialRevision extends DifferentialDAO
       'color.ansi' => $status->getANSIColor(),
     );
 
+    $stack_graph = id(new DifferentialRevisionGraph())
+        ->setSeedPHID($this->getPHID())
+        ->setLoadEntireGraph(true)
+        ->loadGraph();
+
     return array(
+      'stackGraph' => $stack_graph->getEdges(DifferentialRevisionDependsOnRevisionEdgeType::EDGECONST,),
       'title' => $this->getTitle(),
       'uri' => PhabricatorEnv::getURI($this->getURI()),
       'authorPHID' => $this->getAuthorPHID(),


### PR DESCRIPTION
This change will help Lando calculate stack graph without making
repeated requests to the `edge.search` endpoint. A similar approach is
already used in Phabricator when loading the revision page.