### PR TITLE
Bug 1824139 - URL is broken if it contains bugXXX

### DIFF
--- a/src/infrastructure/markup/rule/PhabricatorBugzillaLinkRule.php
+++ b/src/infrastructure/markup/rule/PhabricatorBugzillaLinkRule.php
@@ -8,7 +8,7 @@ final class PhabricatorBugzillaLinkRule extends PhutilRemarkupRule {
 
   public function apply($text) {
     return preg_replace_callback(
-      '/bug\s*#?\s*(\d+)(\s*comment\s*\#?\s*(\d+))?/i',
+      '/\bbug\s*#?\s*(\d+)(\s*comment\s*\#?\s*(\d+))?\b/i',
       array($this, 'markupBugzillaLink'),
       $text
     );


### PR DESCRIPTION
This patch updates the regexp to use word boundaries (\b) so now if we are in a URL it will not try to linkify bugXXX to BMO.