### PR TITLE
DifferentialRevisionInlineTransaction: add isNewFile (bug 1837028)

### DIFF
--- a/src/applications/differential/xaction/DifferentialRevisionInlineTransaction.php
+++ b/src/applications/differential/xaction/DifferentialRevisionInlineTransaction.php
@@ -55,6 +55,7 @@ final class DifferentialRevisionInlineTransaction
       'line' => (int)$comment->getLineNumber(),
       'length' => (int)($comment->getLineLength() + 1),
       'replyToCommentPHID' => $comment->getReplyToCommentPHID(),
+      'isNewFile' => (bool)$comment->getIsNewFile(),
       'isDone' => $is_done,
     );
   }


### PR DESCRIPTION
WIP DO NOT LAND

If `isNewFile` is `false`, then the comment was submitted on the old version of the file (i.e., on the left side, if using split view.) Otherwise it is on the updated version (i.e., the right side). The value appears to be `true` whenever a comment is submitted in "unified" view.