### PR TITLE
Bug 1873965 - Revert changes that made the `attach_inlines` parameter to `differential.createcomment` a no-op

### DIFF
--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -157,10 +157,10 @@ final class DifferentialCreateCommentConduitAPIMethod
       // as it is currently shown to the user, not as it was stored the last
       // time they clicked "Save".
 
-      $draft_content = $inline->getContentForEdit($viewer);
-      if (strlen($draft_content)) {
-        $inline->setContent($draft_content);
-      }
+      // $draft_content = $inline->getContentForEdit($viewer);
+      // if (strlen($draft_content)) {
+      //   $inline->setContent($draft_content);
+      // }
     }
 
     $inlines = mpull($inlines, 'getStorageObject');

--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -94,8 +94,17 @@ final class DifferentialCreateCommentConduitAPIMethod
             ->setContent($content));
     }
 
-    // NOTE: The legacy "attach_inlines" flag is now ignored and has no
-    // effect. See T13513.
+    if ($request->getValue('attach_inlines')) {
+      $type_inline = DifferentialTransaction::TYPE_INLINE;
+      $inlines = DifferentialTransactionQuery::loadUnsubmittedInlineComments(
+        $viewer,
+        $revision);
+      foreach ($inlines as $inline) {
+        $xactions[] = id(new DifferentialTransaction())
+          ->setTransactionType($type_inline)
+          ->attachComment($inline);
+      }
+    }
 
     // NOTE: The legacy "silent" flag is now ignored and has no effect. See
     // T13042.

--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -96,9 +96,12 @@ final class DifferentialCreateCommentConduitAPIMethod
 
     if ($request->getValue('attach_inlines')) {
       $type_inline = DifferentialTransaction::TYPE_INLINE;
-      $inlines = DifferentialTransactionQuery::loadUnsubmittedInlineComments(
-        $viewer,
-        $revision);
+      $inlines = id(new DifferentialDiffInlineCommentQuery())
+        ->setViewer($viewer)
+        ->withRevisionPHIDs(array($revision->getPHID()))
+        ->withPublishedComments(false)
+        ->execute();
+      $inlines = mpull($inlines, 'newInlineCommentObject');
       foreach ($inlines as $inline) {
         $xactions[] = id(new DifferentialTransaction())
           ->setTransactionType($type_inline)

--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -99,7 +99,7 @@ final class DifferentialCreateCommentConduitAPIMethod
       $inlines = id(new DifferentialDiffInlineCommentQuery())
         ->setViewer($viewer)
         ->withRevisionPHIDs(array($revision->getPHID()))
-        ->withPublishedComments(false)
+        ->withPublishableComments(true)
         ->execute();
       $inlines = mpull($inlines, 'newInlineCommentObject');
       foreach ($inlines as $inline) {

--- a/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
+++ b/src/applications/differential/conduit/DifferentialCreateCommentConduitAPIMethod.php
@@ -96,12 +96,9 @@ final class DifferentialCreateCommentConduitAPIMethod
 
     if ($request->getValue('attach_inlines')) {
       $type_inline = DifferentialTransaction::TYPE_INLINE;
-      $inlines = id(new DifferentialDiffInlineCommentQuery())
-        ->setViewer($viewer)
-        ->withRevisionPHIDs(array($revision->getPHID()))
-        ->withPublishableComments(true)
-        ->execute();
-      $inlines = mpull($inlines, 'newInlineCommentObject');
+      $inlines = $this->loadUnsubmittedInlineComments(
+        $viewer,
+        $revision);
       foreach ($inlines as $inline) {
         $xactions[] = id(new DifferentialTransaction())
           ->setTransactionType($type_inline)
@@ -124,6 +121,51 @@ final class DifferentialCreateCommentConduitAPIMethod
       'revisionid'  => $revision->getID(),
       'uri'         => PhabricatorEnv::getURI('/D'.$revision->getID()),
     );
+  }
+
+  public static function loadUnsubmittedInlineComments(
+    PhabricatorUser $viewer,
+    DifferentialRevision $revision) {
+
+    $inlines = id(new DifferentialDiffInlineCommentQuery())
+      ->setViewer($viewer)
+      ->withRevisionPHIDs(array($revision->getPHID()))
+      ->withAuthorPHIDs(array($viewer->getPHID()))
+      ->withHasTransaction(false)
+      ->withIsDeleted(false)
+      ->needReplyToComments(true)
+      ->execute();
+
+    foreach ($inlines as $key => $inline) {
+      $inlines[$key] = DifferentialInlineComment::newFromModernComment(
+        $inline);
+    }
+
+    PhabricatorInlineComment::loadAndAttachVersionedDrafts(
+      $viewer,
+      $inlines);
+
+    // Don't count void inlines when considering draft state.
+    foreach ($inlines as $key => $inline) {
+      if ($inline->isVoidComment($viewer)) {
+        unset($inlines[$key]);
+        continue;
+      }
+
+      // For other inlines: if they have a nonempty draft state, set their
+      // content to the draft state content. We want to submit the comment
+      // as it is currently shown to the user, not as it was stored the last
+      // time they clicked "Save".
+
+      $draft_content = $inline->getContentForEdit($viewer);
+      if (strlen($draft_content)) {
+        $inline->setContent($draft_content);
+      }
+    }
+
+    $inlines = mpull($inlines, 'getStorageObject');
+
+    return $inlines;
   }
 
 }


### PR DESCRIPTION
To restore the functionality of `attach_inlines`, I implemented the following changes:
- Reverts commit 397648855f8bc272db1876da8ce2254d3da82fb9
- Copy the `loadUnsubmittedInlineComments` function from https://github.com/mozilla-conduit/phabricator/blob/397648855f8bc272db1876da8ce2254d3da82fb9/src/applications/differential/query/DifferentialTransactionQuery.php#L10-L53
- Comment out the section of `loadUnsubmittedInlineComments` that uses the `getContentForEdit` method because it was removed