### PR TITLE
Bug 1918751 - stop disabling "View Stack in Lando" for non-Accepted revisions

### DIFF
--- a/moz-extensions/src/lando/events/LandoLinkEventListener.php
+++ b/moz-extensions/src/lando/events/LandoLinkEventListener.php
@@ -43,8 +43,7 @@ final class LandoLinkEventListener extends PhabricatorEventListener {
     $action = id(new PhabricatorActionView())
       ->setHref($lando_stack_uri)
       ->setName(pht('View Stack in Lando'))
-      ->setIcon('fa-link')
-      ->setDisabled(!$object->isAccepted());
+      ->setIcon('fa-link');
 
     $actions = $event->getValue('actions');
     $actions[] = $action;


### PR DESCRIPTION
Graying out the button indicates to the user that they should not click it,
when it is suggested to do so in documentation for submitting uplift
requests.
