### PR TITLE
Bug 1944522 - Add Content-Type header option in Harbormaster HTTP Build step

### DIFF
--- a/src/applications/harbormaster/step/HarbormasterHTTPRequestBuildStepImplementation.php
+++ b/src/applications/harbormaster/step/HarbormasterHTTPRequestBuildStepImplementation.php
@@ -59,9 +59,15 @@ final class HarbormasterHTTPRequestBuildStepImplementation
 
     $method = nonempty(idx($settings, 'method'), 'POST');
 
+    $content_type = $settings['content_type'];
+
     $future = id(new HTTPSFuture($uri))
       ->setMethod($method)
       ->setTimeout(60);
+
+    if ($content_type) {
+      $future->addHeader('Content-Type', $content_type);
+    }
 
     $credential_phid = $this->getSetting('credential');
     if ($credential_phid) {
@@ -105,6 +111,11 @@ final class HarbormasterHTTPRequestBuildStepImplementation
           => PassphrasePasswordCredentialType::CREDENTIAL_TYPE,
         'credential.provides'
           => PassphrasePasswordCredentialType::PROVIDES_TYPE,
+      ),
+      'content_type' => array(
+        'name' => pht('Content-Type header'),
+        'type' => 'text',
+        'required' => false,
       ),
     );
   }


### PR DESCRIPTION
Bug [1944522](https://bugzilla.mozilla.org/show_bug.cgi?id=1944522)

This PR adds an option to the Harbormaster HTTP Build Step to send an extra `Content-Type` header.

The current behaviour is preserved by default: no `Content-Type` header is sent.

![Screenshot 2025-01-29 at 22-16-49 ♻ Make HTTP Request](https://github.com/user-attachments/assets/59093cbd-cfd2-458c-b38b-02e3d926315b)

I was able to test these changes locally, querying my own machine through a public IP from the docker container.
Using a  [debug server](https://gist.githubusercontent.com/phrawzty/62540f146ee5e74ea1ab/raw/8e079bf6230341f1abedbda119570248777a2208/3serv.py), I logged the headers sent by Phabricator when triggering manually a build plan:

```
Accept: */*
Content-Type: application/json;test-bastien
Accept-Encoding: gzip
Content-Length: 0

```