### PR TITLE
Bug 1944522 - Add HTTP Body option in Harbormaster HTTP Build step

### DIFF
--- a/src/applications/harbormaster/step/HarbormasterHTTPRequestBuildStepImplementation.php
+++ b/src/applications/harbormaster/step/HarbormasterHTTPRequestBuildStepImplementation.php
@@ -59,14 +59,19 @@ final class HarbormasterHTTPRequestBuildStepImplementation
 
     $method = nonempty(idx($settings, 'method'), 'POST');
 
-    $content_type = $settings['content_type'];
-
     $future = id(new HTTPSFuture($uri))
       ->setMethod($method)
       ->setTimeout(60);
 
+    $content_type = $settings['content_type'];
     if ($content_type) {
       $future->addHeader('Content-Type', $content_type);
+    }
+
+    $body = $settings['http_body'];
+    if ($body) {
+      $body = $this->mergeVariables('vurisprintf', $body, $variables);
+      $future->setData($body);
     }
 
     $credential_phid = $this->getSetting('credential');
@@ -114,6 +119,11 @@ final class HarbormasterHTTPRequestBuildStepImplementation
       ),
       'content_type' => array(
         'name' => pht('Content-Type header'),
+        'type' => 'text',
+        'required' => false,
+      ),
+      'http_body' => array(
+        'name' => pht('HTTP Body'),
         'type' => 'text',
         'required' => false,
       ),


### PR DESCRIPTION
This is a followup of #46 to support an optional HTTP Body in the Harbormaster HTTP Build step.

Using this PR, I'm able to trigger a Taskcluster hook without any change on Taskcluster.

Here is the build step configuration I'm using:
![Screenshot 2025-01-31 at 08-53-59 ♻ Make HTTP Request](https://github.com/user-attachments/assets/96fb36e3-900c-4d11-af35-1292e4e9a97b)

Using the JSON Content-Type header with a JSON payload, I can provide the Harbormaster build target and other variables using the same `mergeVariables` as for URI formatting.

There is no parsing nor validation whatsoever, it is the responsibility of the Build Step author to write a valid payload.

On Taskcluster:
- here is the [triggerred hook](https://dev.alpha.taskcluster-dev.net/hooks/code-review/test)
- and a [resulting task](https://dev.alpha.taskcluster-dev.net/tasks/DvMKJB3aRj-li8n54wItZQ/definition)
