### PR TITLE
Bug 1955021: use new Lando URL for links in emails

### DIFF
--- a/moz-extensions/src/email/model/EmailRevisionLanded.php
+++ b/moz-extensions/src/email/model/EmailRevisionLanded.php
@@ -36,7 +36,7 @@ class EmailRevisionLanded implements PublicEmailBody
     $hgLink = $resolveRepositoryDetails->resolveHgLink($commit);
 
     $landoLink = null;
-    $landoUri = PhabricatorEnv::getEnvConfig('lando-ui.url');
+    $landoUri = PhabricatorEnv::getEnvConfig('lando.url');
     if ($landoUri) {
       $landoLink = (string) id(new PhutilURI($landoUri))
         ->setPath("/D{$rawRevision->getID()}/");

--- a/moz-extensions/src/email/resolve/ResolveRevisionStatus.php
+++ b/moz-extensions/src/email/resolve/ResolveRevisionStatus.php
@@ -17,7 +17,7 @@ class ResolveRevisionStatus {
   }
 
   public function resolveLandoLink(): string {
-    $landoUri = PhabricatorEnv::getEnvConfig('lando-ui.url');
+    $landoUri = PhabricatorEnv::getEnvConfig('lando.url');
     return (string) (new PhutilURI($landoUri))
       ->setPath('/' . $this->rawRevision->getMonogram() . '/');
   }

--- a/src/applications/differential/controller/DifferentialDiffCreateController.php
+++ b/src/applications/differential/controller/DifferentialDiffCreateController.php
@@ -110,7 +110,7 @@ final class DifferentialDiffCreateController extends DifferentialController {
       $lando_link = phutil_tag(
         'a',
         array(
-          'href' => PhabricatorEnv::getEnvConfig('lando-ui.url'),
+          'href' => PhabricatorEnv::getEnvConfig('lando.url'),
           'target' => '_blank',
         ),
         pht('Lando'));


### PR DESCRIPTION
The `View Stack in Lando` button was updated to use the new
Lando URL, but a few places in the codebase are still using
the old `lando-ui.url` setting. Use `lando.url` in all remaining
places in the codebase.
