### PR TITLE
DifferentialTransactionEditor: ignore missing tree hash (bug 1963679)

### DIFF
--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -1315,13 +1315,17 @@ final class DifferentialTransactionEditor
     switch ($vcs) {
       case DifferentialRevisionControlSystem::GIT:
         foreach ($data as $commit) {
+          $commit_hash = $commit['commit'];
+          $commit_tree = $commit['tree'] ?? "";
+
           $hashes[] = array(
             ArcanistDifferentialRevisionHash::HASH_GIT_COMMIT,
-            $commit['commit'],
+            $commit_hash,
           );
+
           $hashes[] = array(
             ArcanistDifferentialRevisionHash::HASH_GIT_TREE,
-            $commit['tree'],
+            $commit_tree,
           );
         }
         break;

--- a/src/applications/differential/editor/DifferentialTransactionEditor.php
+++ b/src/applications/differential/editor/DifferentialTransactionEditor.php
@@ -1316,7 +1316,7 @@ final class DifferentialTransactionEditor
       case DifferentialRevisionControlSystem::GIT:
         foreach ($data as $commit) {
           $commit_hash = $commit['commit'];
-          $commit_tree = $commit['tree'] ?? "";
+          $commit_tree = $commit['tree'] ?? "0000000000000000000000000000000000000000";
 
           $hashes[] = array(
             ArcanistDifferentialRevisionHash::HASH_GIT_COMMIT,


### PR DESCRIPTION
- temporary fix to allow uplifts created from mercurial commits