### PR TITLE
fix Incorrect suffix check

### DIFF
--- a/webroot/rsrc/externals/javelin/lib/Resource.js
+++ b/webroot/rsrc/externals/javelin/lib/Resource.js
@@ -47,7 +47,7 @@ JX.install('Resource', {
           setTimeout(JX.bind(JX.Resource, JX.Resource._complete, resource), 0);
         } else if (!JX.Resource._loading[resource]) {
           JX.Resource._loading[resource] = true;
-          if (path.indexOf('.css') == path.length - 4) {
+          if (path.endsWith('.css')) {
             JX.Resource._loadCSS(resource);
           } else {
             JX.Resource._loadJS(resource);


### PR DESCRIPTION
https://github.com/mozilla-conduit/phabricator/blob/13264b976f25e81a0d5afa544e9a40d9e5b4c112/webroot/rsrc/externals/javelin/lib/Resource.js#L50-L50

fix the issue, replace the `indexOf`-based suffix check with a more robust approach. The best solution is to use `String.prototype.endsWith`, which is specifically designed for this purpose and avoids the pitfalls of `indexOf`. If `endsWith` is not available in the runtime environment, explicitly handle the `-1` case by checking the relative lengths of the strings.

In this case, we will replace `path.indexOf('.css') == path.length - 4` with `path.endsWith('.css')`. This change ensures that the code correctly identifies whether `path` ends with `.css` without relying on potentially error-prone calculations.


The `indexOf` and `lastIndexOf` methods are sometimes used to check if a substring occurs at a certain position in a string. However, if the returned index is compared to an expression that might evaluate to -1, the check may pass in some cases where the substring was not found at all. Specifically, this can easily happen when implementing `endsWith` using `indexOf`.


### Recommendation
Use `String.prototype.endsWith` if it is available. Otherwise, explicitly handle the -1 case, either by checking the relative lengths of the strings, or by checking if the returned index is -1.

## POC
The following uses `lastIndexOf` to determine if the string `x` ends with the string `y`:
```js
function endsWith(x, y) {
  return x.lastIndexOf(y) === x.length - y.length;
}
```
However, if `y` is one character longer than `x`, the right-hand side `x.length - y.length` becomes -1, which then equals the return value of `lastIndexOf`. This will make the test pass, even though `x` does not end with `y`.

To avoid this, explicitly check for the -1 case:
```js
function endsWith(x, y) {
  let index = x.lastIndexOf(y);
  return index !== -1 && index === x.length - y.length;
}
```
## References
[String.prototype.endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith)
[String.prototype.indexOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)