### PR TITLE
PhabricatorRepositoryCommitPublishWorker: move relevance logic (bug 1963406)

### DIFF
--- a/src/applications/repository/worker/PhabricatorRepositoryCommitPublishWorker.php
+++ b/src/applications/repository/worker/PhabricatorRepositoryCommitPublishWorker.php
@@ -456,6 +456,25 @@ final class PhabricatorRepositoryCommitPublishWorker
       return;
     }
 
+    $revisionRepositoryCallsign = $revision->getRepository()->getCallsign();
+    $commitRepositoryCallsign = $commit->getRepository()->getCallsign();
+
+    $mustCloseRevision = false;
+    if ($revisionRepositoryCallsign === $commitRepositoryCallsign) {
+      $mustCloseRevision = true;
+    } else {
+      $config = PhabricatorEnv::getEnvConfig('diffusion.legacy-repos-mapping');
+      if (array_key_exists($revisionRepositoryCallsign, $config)) {
+        if ($config[$revisionRepositoryCallsign] === $commitRepositoryCallsign) {
+          $mustCloseRevision = true;
+        }
+      }
+    }
+
+    if (!$mustCloseRevision) {
+      return;
+    }
+
     // NOTE: This is very old code from when revisions had a single reviewer.
     // It still powers the "Reviewer (Deprecated)" field in Herald, but should
     // be removed.


### PR DESCRIPTION
- move repository matching check to PhabricatorRepositoryCommitPublishWorker

Prior to this change, a commit that matches a revision was still going through code in both PhabricatorRepositoryCommitPublishWorker and DiffusionUpdateObjectAfterCommitWorker that was making changes to the revision other than changing the status. With this change, the revisions will still show a link to the commit, however none of the code in DiffusionUpdateObjectAfterCommitWorker will be triggered.