### PR TITLE
chore(ci): Add build and push Github Action.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,10 @@ jobs:
             if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               docker push "$DOCKERHUB_REPO:latest"
             else
-              docker tag "$DOCKERHUB_REPO" "$DOCKERHUB_REPO:$CIRCLE_BRANCH"
-              docker push "$DOCKERHUB_REPO:$CIRCLE_BRANCH"
+              # Replace forward slashes with hyphens in branch name for Docker tag
+              SAFE_BRANCH_NAME=$(echo "$CIRCLE_BRANCH" | tr '/' '-')
+              docker tag "$DOCKERHUB_REPO" "$DOCKERHUB_REPO:$SAFE_BRANCH_NAME"
+              docker push "$DOCKERHUB_REPO:$SAFE_BRANCH_NAME"
             fi
 
 workflows:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,21 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build-and-push:
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main
+    with:
+      image_name: phabricator
+      gar_name: phabricator-prod
+      project_id: moz-fx-phabricator-prod
+      prebuild_script: true
+      image_tag_metadata: ${{ github.sha }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - main
+      - chore/build-and-push-gha # temporary branch for testing
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - chore/build-and-push-gha # temporary branch for testing
 
 jobs:
   build-and-push:


### PR DESCRIPTION
# Description
This PR adds a Github Action to build and push images on commits to the `main`/`master` branch to the new Google Artifact Registry.

I have not translated the test steps from the existing CircleCI configuration. This will be left to the maintainers of the project to implement as they prefer.

# Related ticket
* [SVCSE-3411](https://mozilla-hub.atlassian.net/browse/SVCSE-3411)