### PR TITLE
fix(gha): Set package permission to none

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/gha-package-permission
 
 jobs:
   build-and-push:
@@ -11,6 +12,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: none
     uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main
     with:
       image_name: phabricator


### PR DESCRIPTION
# Description
See [error ](https://github.com/mozilla-conduit/phabricator/actions/runs/16475109517)
> The workflow is not valid. .github/workflows/build-and-push.yaml (Line: 9, Col: 3): Error calling workflow 'mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main'. The nested job 'build-and-push' is requesting 'packages: write', but is only allowed 'packages: none'.

Default workflow permission tries to use `packages: write` but we don't need package permissions.