### PR TITLE
fix(gha): Pin workflow version and use prebuild default script.

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -12,9 +12,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@main
-    with:
+    uses: mozilla-it/deploy-actions/.github/workflows/build-and-push.yml@v4.0.4
       image_name: phabricator
       gar_name: phabricator-prod
       project_id: moz-fx-phabricator-prod
-      prebuild_script: true


### PR DESCRIPTION
# Description
Pin workflow version and use default `prebuild_script` that generates a `version.json` file.

# Related ticket
