### PR TITLE
Bug 1988566 - uplift request transaction is no longer available in `differential.revision.edit` API

### DIFF
--- a/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
+++ b/moz-extensions/src/differential/customfield/DifferentialUpliftRequestCustomField.php
@@ -63,7 +63,7 @@ final class DifferentialUpliftRequestCustomField
 
     public function shouldAppearInEditView() {
         // Should the field appear in Edit Revision feature
-        return false;
+        return true;
     }
 
     // How the uplift text is rendered in the "Details" section.


### PR DESCRIPTION
Mark `shouldAppearInEditView` as `true` in the `DifferentialUpliftRequestCustomField`
extension.
