### PR TITLE
Bug 2027831 - Remove final from ReviewHelperServiceException to allow subclassing

### DIFF
--- a/moz-extensions/src/reviewhelper/exception/ReviewHelperServiceException.php
+++ b/moz-extensions/src/reviewhelper/exception/ReviewHelperServiceException.php
@@ -3,4 +3,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-final class ReviewHelperServiceException extends Exception {}
+class ReviewHelperServiceException extends Exception {}


### PR DESCRIPTION
ReviewHelperIneligibleRevisionException needs to extend this class, so it cannot be declared final.