### PR TITLE
Bug 2004981 - Prefix STAMPS entries with underscore in legacy mail notifications

### DIFF
--- a/src/applications/people/phid/PhabricatorPeopleUserPHIDType.php
+++ b/src/applications/people/phid/PhabricatorPeopleUserPHIDType.php
@@ -46,7 +46,7 @@ final class PhabricatorPeopleUserPHIDType extends PhabricatorPHIDType {
         ->setURI('/p/'.$username.'/')
         ->setFullName($user->getFullName())
         ->setImageURI($user->getProfileImageURI())
-        ->setMailStampName('@'.$username);
+        ->setMailStampName('_@'.$username);
 
       if ($user->getIsMailingList()) {
         $handle->setIcon('fa-envelope-o');

--- a/src/applications/project/phid/PhabricatorProjectProjectPHIDType.php
+++ b/src/applications/project/phid/PhabricatorProjectProjectPHIDType.php
@@ -45,7 +45,7 @@ final class PhabricatorProjectProjectPHIDType extends PhabricatorPHIDType {
 
       if (strlen($slug)) {
         $handle->setObjectName('#'.$slug);
-        $handle->setMailStampName('#'.$slug);
+        $handle->setMailStampName('_#'.$slug);
         $handle->setURI("/tag/{$slug}/");
       } else {
         // We set the name to the project's PHID to avoid a parse error when a


### PR DESCRIPTION
[Bug 2004981](https://bugzilla.mozilla.org/show_bug.cgi?id=2004981)

Prepends an underscore to user (@) and project (#) mail stamp names so STAMPS entries render as _@username and _#slug to fix accuracy issues when Gmail filtering.

