### PR TITLE
Bug 2063953 - Don't fatal on Herald transcripts with collected details

### DIFF
--- a/src/applications/herald/controller/HeraldTranscriptController.php
+++ b/src/applications/herald/controller/HeraldTranscriptController.php
@@ -717,8 +717,8 @@ final class HeraldTranscriptController extends HeraldController {
       ->setName(pht('Field Values'))
       ->setIcon('fa-file-text-o');
 
-    $xaction_phids = $this->getTranscriptTransactionPHIDs($xscript);
-    $has_xactions = (bool)$xaction_phids;
+    $has_xactions = $xscript->getObjectTranscript()
+      && $this->getTranscriptTransactionPHIDs($xscript);
 
     $nav->newLink('xactions')
       ->setName(pht('Transactions'))


### PR DESCRIPTION
`HeraldTranscriptGarbageCollector` blanks the serialized columns with `""`
rather than `serialize(null)`, so `unserialize()` returns `false` and
`getObjectTranscript()` yields a bool. `handleRequest` guards against a
missing object transcript, but `newSideNavView` runs first and calls
`getAppliedTransactionPHIDs()` on the bool.

Upstream fix: https://we.phorge.it/rP54ee51d7abd0c527a2e2d5d071f38eff71c367ea
